### PR TITLE
Fixes 

### DIFF
--- a/src/data/CorrectedTalents.js
+++ b/src/data/CorrectedTalents.js
@@ -256,5 +256,17 @@ export const correctedTalentsData = [
         tier: 3,
         talent: 3,
         description: 'Increases total Power Level by 7.5%. This is calculated before other buffs are applied.'
+    },
+    {
+        careerId: 19,
+        tier: 3,
+        talent: 3,
+        description: 'Increases total Power Level by 7.5%. This is calculated before other buffs are applied.'
+    },
+    {
+        careerId: 20,
+        tier: 3,
+        talent: 3,
+        description: 'Increases total Power Level by 7.5%. This is calculated before other buffs are applied.'
     }
 ]

--- a/src/data/CorrectedTalents.js
+++ b/src/data/CorrectedTalents.js
@@ -256,11 +256,5 @@ export const correctedTalentsData = [
         tier: 3,
         talent: 3,
         description: 'Increases total Power Level by 7.5%. This is calculated before other buffs are applied.'
-    },
-    {
-        careerId: 19,
-        tier: 5,
-        talent: 1,
-        description: 'Blesses the party with 25% increased power versus Monsters.'
     }
 ]

--- a/src/data/Heroes.js
+++ b/src/data/Heroes.js
@@ -275,7 +275,7 @@ export const heroesData = {
 			},
 			{
 				"name": "Soot Shield",
-				"description": "Igniting an enemy reduces damage taken by 80.0% for 5 seconds. Stacks up to 3 times."
+				"description": "Igniting an enemy reduces damage taken by 8.0% for 5 seconds. Stacks up to 3 times."
 			},
 			{
 				"name": "Fires from Ash",

--- a/src/data/Heroes.js
+++ b/src/data/Heroes.js
@@ -1895,11 +1895,11 @@ export const heroesData = {
 			},
 			{
 				"name": "Prayer of Vengence",
-				"description": "Bless the party with 35% increased Critical Strike Damage."
+				"description": "Bless the party with 25% power versus Monsters."
 			},
 			{
 				"name": "Prayer of Might",
-				"description": "Bless the party with 25% power versus Monsters."
+				"description": "Bless the party with 25% increased Stagger Power."
 			},
 			{
 				"name": "Prayer of Hardiness",


### PR DESCRIPTION
Fixed Warrior Priest's "Prayer of Vengeance" & "Prayer of Might" having the same description.
Removed Warrior Priest's "Prayer of Vengeance" entry in CorrectedTalents.js as the default description now matches the behaviour.
Added an entry for Warrior Priest and Necromancer's "Enhanced Power" talent to CorrectedTalents.js.
Fixed a typo for Battle Wizard's "Soot Shield".